### PR TITLE
Example fixes

### DIFF
--- a/input/examples/admission-diagnosis-section-example.xml
+++ b/input/examples/admission-diagnosis-section-example.xml
@@ -15,7 +15,7 @@
           <!-- ** Problem Observation ** -->
           <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
           <id root="AB1791B0-5C71-11DB-B0DE-0800200C9A66" />
-          <code code="64572001" displayName="Condition" 
+          <code code="64572001" displayName="Disease" 
             codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
           <statusCode code="completed" />
           <effectiveTime>

--- a/input/examples/advance-directive-observation-example.xml
+++ b/input/examples/advance-directive-observation-example.xml
@@ -56,7 +56,7 @@
         <code code="163W00000X" 
              codeSystem="2.16.840.1.113883.6.101" 
              codeSystemName="Health Care Provider Taxonomy (HIPAA)" 
-             displayName="Registered nurse" />
+             displayName="Nursing Service Providers; Registered Nurse" />
         <addr use="H">
           <streetAddressLine>23 Anywhere Street</streetAddressLine>
           <city>El Paso</city>
@@ -77,7 +77,7 @@
     <participant typeCode="CST">
       <templateId root="2.16.840.1.113883.10.20.1.58" />
       <participantRole classCode="AGNT">
-        <code code="MTH" codeSystem="2.16.840.1.113883.5.111" displayName="Mother" />
+        <code code="MTH" codeSystem="2.16.840.1.113883.5.111" displayName="mother" />
          <addr use="H">
             <streetAddressLine>23 Anywhere Street</streetAddressLine>
             <city>El Paso</city>

--- a/input/examples/advance-directive-organizer-example.xml
+++ b/input/examples/advance-directive-organizer-example.xml
@@ -18,7 +18,7 @@
     <assignedAuthor>
       <id extension="5555555551" root="2.16.840.1.113883.4.6" />
       <code code="163W00000X" 
-        displayName="Registered nurse" 
+        displayName="Nursing Service Providers; Registered Nurse" 
         codeSystem="2.16.840.1.113883.6.101"
         codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
       <addr use="H">
@@ -46,7 +46,7 @@
     <assignedEntity>
       <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
       <code code="163W00000X" 
-        displayName="Registered nurse" 
+        displayName="Nursing Service Providers; Registered Nurse" 
         codeSystem="2.16.840.1.113883.6.101" 
         codeSystemName="Health Care Provider Taxonomy (HIPAA)" />
       <addr use="H">
@@ -77,7 +77,7 @@
       <code code="163W00000X" 
         codeSystem="2.16.840.1.113883.6.101" 
         codeSystemName="Health Care Provider Taxonomy (HIPAA)" 
-        displayName="Registered nurse" />
+        displayName="Nursing Service Providers; Registered Nurse" />
       <addr use="H">
         <streetAddressLine>23 Anywhere Street</streetAddressLine>
         <city>El Paso</city>

--- a/input/examples/advance-directives-section-example.xml
+++ b/input/examples/advance-directives-section-example.xml
@@ -1,7 +1,7 @@
 <section xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
   <!-- C-CDA Advance Directives Section (required entries)template id -->
   <templateId root="2.16.840.1.113883.10.20.22.2.21.1" extension="2015-08-01" />
-  <code code="42348-3" codeSystem="2.16.840.1.113883.6.1" />
+  <code code="42348-3" codeSystem="2.16.840.1.113883.6.1" displayName="Advance directives" />
   <title>ADVANCE DIRECTIVES</title>
   <text>
        Narrative Text

--- a/input/examples/allergy-concern-act-example.xml
+++ b/input/examples/allergy-concern-act-example.xml
@@ -19,7 +19,7 @@
     <assignedAuthor>
       <id extension="555555555" root="2.16.840.1.113883.4.6" />
       <code code="207QA0505X" 
-        displayName="Adult Medicine" 
+        displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" 
         codeSystem="2.16.840.1.113883.6.101"
         codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
       <addr use="H">

--- a/input/examples/allergy-intolerance-observation-example.xml
+++ b/input/examples/allergy-intolerance-observation-example.xml
@@ -20,7 +20,7 @@
     <assignedAuthor>
       <id extension="555555555" root="2.16.840.1.113883.4.6" />
       <code code="207QA0505X" 
-        displayName="Adult Medicine" 
+        displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" 
         codeSystem="2.16.840.1.113883.6.101"
         codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
       <addr use="H">
@@ -39,7 +39,7 @@
   <participant typeCode="CSM">
     <participantRole classCode="MANU">
       <playingEntity classCode="MMAT">
-        <code code="10395" displayName="Tetracycline" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" />
+        <code code="10395" displayName="tetracycline" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" />
       </playingEntity>
     </participantRole>
   </participant>

--- a/input/examples/allergy-to-food-egg.xml
+++ b/input/examples/allergy-to-food-egg.xml
@@ -44,7 +44,7 @@
 				<time value="20140104"/>
 				<assignedAuthor>
 					<id extension="99999999" root="2.16.840.1.113883.4.6"/>
-					<code code="207Q00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Health Care Provider Taxonomy" displayName="Family Medicine" />
+					<code code="207Q00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Health Care Provider Taxonomy" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine" />
 					<addr use="H">
 						<streetAddressLine>23 Anywhere Street</streetAddressLine>
 						<city>El Paso</city>
@@ -78,13 +78,13 @@
 						<low value="1998"/>
 					</effectiveTime>
 					<!-- This specifies that the allergy is to a food in contrast to other allergies (drug) -->
-					<value xsi:type="CD" code="414285001" displayName="Food allergy (disorder)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"></value>
+					<value xsi:type="CD" code="414285001" displayName="Allergy to food (finding)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"></value>
 					<author>
 						<templateId root="2.16.840.1.113883.10.20.22.4.119"/>
 						<time value="20140104"/>
 						<assignedAuthor>
 							<id extension="99999999" root="2.16.840.1.113883.4.6"/>
-							<code code="207Q00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Health Care Provider Taxonomy" displayName="Family Medicine" />
+							<code code="207Q00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Health Care Provider Taxonomy" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine" />
 							<addr use="H">
 								<streetAddressLine>23 Anywhere Street</streetAddressLine>
 								<city>El Paso</city>
@@ -152,7 +152,7 @@
 										<reference value="#allergy5reactionseverity"/>
 									</text>
 									<statusCode code="completed"/>
-									<value xsi:type="CD" code="6736007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="moderate"/>
+									<value xsi:type="CD" code="6736007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Moderate"/>
 								</observation>
 							</entryRelationship>
 						</observation>

--- a/input/examples/assessment-section-example.xml
+++ b/input/examples/assessment-section-example.xml
@@ -2,7 +2,7 @@
   <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
   <code codeSystem="2.16.840.1.113883.6.1" 
          codeSystemName="LOINC" code="51848-0" 
-         displayName="ASSESSMENTS"/>
+         displayName="Evaluation note"/>
   <title>ASSESSMENTS</title>
   <text>
       ...

--- a/input/examples/care-plan-caregiver-participant-example.xml
+++ b/input/examples/care-plan-caregiver-participant-example.xml
@@ -1,8 +1,8 @@
 <participant typeCode="IND" xmlns="urn:hl7-org:v3">
-  <functionCode code="407543004" displayName="Primary Carer" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+  <functionCode code="407543004" displayName="Primary caregiver" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
   <!-- Caregiver -->
   <associatedEntity classCode="CAREGIVER">
-    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" displayName="mother" />
     <addr>
       <streetAddressLine>17 Daws Rd.</streetAddressLine>
       <city>Ann Arbor</city>

--- a/input/examples/care-plan-complete-example.xml
+++ b/input/examples/care-plan-complete-example.xml
@@ -27,7 +27,7 @@
 	<code code="52521-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Overall Plan of Care/Advance Care Directives"/>
 	<title>Good Health Hospital Care Plan</title>
 	<effectiveTime value="201308201120-0800"/>
-	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="normal" />
 	<languageCode code="en-US"/>
 	<!-- This document is the second document in the set (see setId for id for the set -->
 	<setId root="004bb033-b948-4f4c-b5bf-a8dbd7d8dd40"/>
@@ -70,7 +70,7 @@
 				<!-- CDC Race and Ethnicity code set contains the five minimum race and ethnicity categories defined by OMB Standards -->
 				<raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<!-- The raceCode extension is only used if raceCode is valued -->
-				<sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
+				<sdtc:raceCode code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<guardian>
 					<code code="POWATT" displayName="Power of Attorney" codeSystem="2.16.840.1.113883.1.11.19830" codeSystemName="ResponsibleParty"/>
@@ -128,7 +128,7 @@
 		<time value="20130730"/>
 		<assignedAuthor>
 			<id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c"/>
-			<code code="163W00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)" displayName="Registered nurse"/>
+			<code code="163W00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)" displayName="Nursing Service Providers; Registered Nurse"/>
 			<addr>
 				<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 				<city>Portland</city>
@@ -259,7 +259,7 @@
 		<sdtc:signatureText mediaType="text/xml" representation="B64">U2lnbmVkIGJ5IE51cnNlIE5pZ2h0aW5nYWxl</sdtc:signatureText>
 		<assignedEntity>
 			<id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c"/>
-			<code code="163W00000X" codeSystem="2.16.840.1.113883.6.101" displayName="Registered nurse"/>
+			<code code="163W00000X" codeSystem="2.16.840.1.113883.6.101" displayName="Nursing Service Providers; Registered Nurse"/>
 			<addr>
 				<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 				<city>Portland</city>
@@ -289,7 +289,7 @@
 		<sdtc:signatureText mediaType="text/xml" representation="B64">U2lnbmVkIGJ5IEV2ZSBFdmVyeXdvbWFu</sdtc:signatureText>
 		<assignedEntity>
 			<id extension="444222222" root="2.16.840.1.113883.4.1"/>
-			<code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="RoleCode"/>
+			<code code="ONESELF" displayName="self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="RoleCode"/>
 			<addr use="HP">
 				<!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
 				<streetAddressLine>2222 Home Street</streetAddressLine>
@@ -312,7 +312,7 @@
          If the date in the time element is in the future, then this is the date of the next scheduled review. -->
 	<!-- This example shows a Care Plan Review that has already taken place -->
 	<participant typeCode="VRF">
-		<functionCode code="425268008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Review of Care Plan"/>
+		<functionCode code="425268008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Review of care plan"/>
 		<time value="20130801"/>
 		<associatedEntity classCode="ASSIGNED">
 			<id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c"/>
@@ -323,7 +323,7 @@
   If the date in the time element is in the future,  then this is the date of the next scheduled review. -->
 	<!-- This example shows a Scheduled Care Plan Review that is in the future -->
 	<participant typeCode="VRF">
-		<functionCode code="425268008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Review of Care Plan"/>
+		<functionCode code="425268008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Review of care plan"/>
 		<time value="20131001"/>
 		<associatedEntity classCode="ASSIGNED">
 			<id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c"/>
@@ -386,7 +386,7 @@
 				<time value="20130715223615-0800"/>
 				<assignedEntity>
 					<id extension="5555555555" root="2.16.840.1.113883.4.6"/>
-					<code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+					<code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
 					<addr>
 						<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 						<city>Portland</city>

--- a/input/examples/care-plan-patient-authenticator-example.xml
+++ b/input/examples/care-plan-patient-authenticator-example.xml
@@ -6,6 +6,6 @@
   <sdtc:signatureText mediaType="text/xml" representation="B64">RHJpbmsgbW9yZSBPdmFsdGluZQ==</sdtc:signatureText>
   <assignedEntity>
     <id extension="996-756-495" root="2.16.840.1.113883.19.5" />
-    <code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
+    <code code="ONESELF" displayName="self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
   </assignedEntity>
 </authenticator>

--- a/input/examples/care-plan-performer-example.xml
+++ b/input/examples/care-plan-performer-example.xml
@@ -2,7 +2,7 @@
   <time value="20130715223615-0800" />
   <assignedEntity>
     <id extension="5555555555" root="2.16.840.1.113883.4.6" />
-    <code code="59058001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="General Physician" />
+    <code code="59058001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="General physician" />
     <addr>
       <streetAddressLine>1004 Healthcare Drive </streetAddressLine>
       <city>Portland</city>

--- a/input/examples/care-plan-relateddocument-example.xml
+++ b/input/examples/care-plan-relateddocument-example.xml
@@ -3,7 +3,7 @@
 <relatedDocument typeCode="RPLC" xmlns="urn:hl7-org:v3">
   <parentDocument>
     <id root="223769be-f6ee-4b04-a0ce-b56ae998c880" />
-    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Plan" />
+    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Plan of care note" />
     <setId root="004bb033-b948-4f4c-b5bf-a8dbd7d8dd40" />
     <versionNumber value="1" />
   </parentDocument>

--- a/input/examples/care-plan-review-example.xml
+++ b/input/examples/care-plan-review-example.xml
@@ -5,7 +5,7 @@
   then this is the date of the next scheduled review. -->
 <!-- This example shows a Care Plan Review that has already taken place -->
 <participant typeCode="IND" xmlns="urn:hl7-org:v3">
-  <functionCode code="425268008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Review of Care Plan" />
+  <functionCode code="425268008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Review of care plan" />
   <time value="20130801" />
   <associatedEntity classCode="ASSIGNED">
     <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />

--- a/input/examples/caregiver-characteristics-example.xml
+++ b/input/examples/caregiver-characteristics-example.xml
@@ -11,7 +11,7 @@
   <participant typeCode="IND">
     <participantRole classCode="CAREGIVER">
       <code code="MTH" codeSystem="2.16.840.1.113883.5.111"
-                    displayName="Mother"/>
+                    displayName="mother"/>
     </participantRole>
   </participant>
 </observation>

--- a/input/examples/ccd-author-example.xml
+++ b/input/examples/ccd-author-example.xml
@@ -2,7 +2,7 @@
   <time value="201209151030-0800" />
   <assignedAuthor>
     <id extension="5555555555" root="2.16.840.1.113883.4.6" />
-    <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy" />
+    <code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy" />
     <addr>
       <streetAddressLine>1004 Healthcare Drive </streetAddressLine>
       <city>Portland</city>

--- a/input/examples/ccd-performer-example.xml
+++ b/input/examples/ccd-performer-example.xml
@@ -4,7 +4,7 @@
   </functionCode>
   <assignedEntity>
     <id extension="5555555555" root="2.16.840.1.113883.4.6" />
-    <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
+    <code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
     <addr use="H">
       <streetAddressLine>23 Anywhere Street</streetAddressLine>
       <city>El Paso</city>

--- a/input/examples/ccd-serviceevent-example.xml
+++ b/input/examples/ccd-serviceevent-example.xml
@@ -17,7 +17,7 @@
       </functionCode>
       <assignedEntity>
         <id extension="5555555555" root="2.16.840.1.113883.4.6" />
-        <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
+        <code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
         <addr use="H">
           <streetAddressLine>23 Anywhere Street</streetAddressLine>
           <city>El Paso</city>

--- a/input/examples/characteristics-of-home-environment-example.xml
+++ b/input/examples/characteristics-of-home-environment-example.xml
@@ -7,5 +7,5 @@
   <text><reference value="#characteristics"/></text>
   <statusCode code="completed" />
   <effectiveTime value="20130312" />
-  <value xsi:type="CD" code="308899009" displayName="unsatisfactory living conditions (finding)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+  <value xsi:type="CD" code="308899009" displayName="Unsatisfactory living conditions (finding)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
 </observation>

--- a/input/examples/complications-section-example.xml
+++ b/input/examples/complications-section-example.xml
@@ -1,6 +1,6 @@
 <section xmlns="urn:hl7-org:v3">
   <templateId root="2.16.840.1.113883.10.20.22.2.37" extension="2015-08-01" />
-  <code code="55109-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Complications" />
+  <code code="55109-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Complications Document" />
   <title>Complications</title>
   <text>Asthmatic symptoms while under general anesthesia.</text>
 </section>

--- a/input/examples/consultation-note-complete-example.xml
+++ b/input/examples/consultation-note-complete-example.xml
@@ -24,10 +24,10 @@
 	<!-- Consultation Note V2  -->
 	<templateId root="2.16.840.1.113883.10.20.22.1.4" extension="2015-08-01"/>
 	<id extension="TT988" root="2.16.840.1.113883.19.5.99999.1"/>
-	<code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="11488-4" displayName="Consultation Note"/>
+	<code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="11488-4" displayName="Consult note"/>
 	<title>Community Health Consult Note</title>
 	<effectiveTime value="201308010500-0800"/>
-	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="normal" />
 	<languageCode code="en-US"/>
 	<setId extension="sTT988" root="2.16.840.1.113883.19.5.99999.19"/>
 	<versionNumber value="1"/>
@@ -66,7 +66,7 @@
 					categories defined by OMB Standards -->
 				<raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<!-- The raceCode extension is only used if raceCode is valued -->
-				<sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
+				<sdtc:raceCode code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<guardian>
 					<code code="POWATT" displayName="Power of Attorney" codeSystem="2.16.840.1.113883.1.11.19830" codeSystemName="ResponsibleParty"/>
@@ -124,7 +124,7 @@
 		<time value="20130731"/>
 		<assignedAuthor>
 			<id extension="555555555" root="2.16.840.1.113883.4.6"/>
-			<code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+			<code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
 			<addr>
 				<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 				<city>Portland</city>
@@ -217,7 +217,7 @@
 		<signatureCode code="S"/>
 		<assignedEntity>
 			<id extension="555555555" root="2.16.840.1.113883.4.6"/>
-			<code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+			<code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
 			<addr>
 				<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 				<city>Portland</city>
@@ -241,7 +241,7 @@
 		<signatureCode code="S"/>
 		<assignedEntity>
 			<id extension="555555555" root="2.16.840.1.113883.4.6"/>
-			<code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+			<code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
 			<addr>
 				<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 				<city>Portland</city>
@@ -287,13 +287,13 @@
 	<inFulfillmentOf typeCode="FLFS">
 		<order classCode="ACT" moodCode="RQO">
 			<id root="2.16.840.1.113883.6.96" extension="1298989898"/>
-			<code code="388975008" displayName="Weight Reduction Consultation" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+			<code code="388975008" displayName="Weight reduction consultation" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
 		</order>
 	</inFulfillmentOf>
 	<componentOf>
 		<encompassingEncounter>
 			<id extension="9937012" root="2.16.840.1.113883.19"/>
-			<code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" code="99213" displayName="Evaluation and Management"/>
+			<code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" code="99213" displayName="Office or other outpatient visit for the evaluation and management of an established patient, which requires a medically appropriate history and/or examination and low level of medical decision making. When using time for code selection, 20-29 minutes of total time is spent on the date of the encounter."/>
 			<effectiveTime>
 				<low value="20130731"/>
 				<high value="20130731"/>

--- a/input/examples/consultation-note-infulfillmentof-example.xml
+++ b/input/examples/consultation-note-infulfillmentof-example.xml
@@ -1,6 +1,6 @@
 <inFulfillmentOf typeCode="FLFS" xmlns="urn:hl7-org:v3">
   <order classCode="ACT" moodCode="RQO">
     <id root="2.16.840.1.113883.6.96" extension="1298989898" />
-    <code code="388975008" displayName="Weight Reduction Consultation" codeSystem="2.16.840.1.113883.6.96" codeSystemName="CPT4" />
+    <code code="388975008" displayName="Weight reduction consultation" codeSystem="2.16.840.1.113883.6.96" codeSystemName="CPT4" />
   </order>
 </inFulfillmentOf>

--- a/input/examples/criticality-observation-example.xml
+++ b/input/examples/criticality-observation-example.xml
@@ -6,5 +6,5 @@
     <reference value="#criticality"/>
   </text>
   <statusCode code="completed"/>
-  <value xsi:type="CD" code="CRITH" displayName="High Criticality" codeSystem="2.16.840.1.113883.5.1063" codeSystemName="ObservationValue"/>
+  <value xsi:type="CD" code="CRITH" displayName="high criticality" codeSystem="2.16.840.1.113883.5.1063" codeSystemName="ObservationValue"/>
 </observation>

--- a/input/examples/discharge-diagnosis-section-example.xml
+++ b/input/examples/discharge-diagnosis-section-example.xml
@@ -20,7 +20,7 @@
           <!-- ** Problem Observation ** -->
           <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
           <id root="AB1791B0-5C71-11DB-B0DE-0800200C9A66" />
-          <code code="64572001" displayName="Condition" 
+          <code code="64572001" displayName="Disease" 
             codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
           <!-- The statusCode reflects the status of the observation itself -->
           <statusCode code="completed" />
@@ -35,7 +35,7 @@
           <value xsi:type="CD"
             code="271959005" 
             codeSystem="2.16.840.1.113883.6.96"  
-            displayName="Diverticula of intestine" />
+            displayName="Simple diverticular disease of large intestine" />
         </observation>
       </entryRelationship>
     </act>

--- a/input/examples/discharge-summary-encompassingencounter-example.xml
+++ b/input/examples/discharge-summary-encompassingencounter-example.xml
@@ -1,7 +1,7 @@
 <componentOf xmlns="urn:hl7-org:v3">
   <encompassingEncounter>
     <id extension="9937012" root="2.16.840.1.113883.19" />
-    <code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" code="99213" displayName="Evaluation and Management" />
+    <code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" code="99213" displayName="Office or other outpatient visit for the evaluation and management of an established patient, which requires a medically appropriate history and/or examination and low level of medical decision making. When using time for code selection, 20-29 minutes of total time is spent on the date of the encounter." />
     <effectiveTime>
       <low value="20090227130000+0500" />
       <high value="20090227130000+0500" />

--- a/input/examples/drug-monitoring-act-example.xml
+++ b/input/examples/drug-monitoring-act-example.xml
@@ -1,7 +1,7 @@
 <act classCode="ACT" moodCode="INT" xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <templateId root="2.16.840.1.113883.10.20.22.4.123" />
     <id root="2a620155-9d11-439e-92b3-5d9815ff4ee8" />
-    <code code="395170001" displayName="medication monitoring(regime/therapy" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    <code code="395170001" displayName="Medication monitoring" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
     <text><reference value="#drugMonitoring"/></text>
     <statusCode code="completed" />
     <effectiveTime>

--- a/input/examples/encounter-activity-example.xml
+++ b/input/examples/encounter-activity-example.xml
@@ -1,7 +1,7 @@
 <encounter classCode="ENC" moodCode="EVN" xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc">
   <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01" />
   <id root="2a620155-9d11-439e-92b3-5d9815ff4de8" />
-  <code code="99213" displayName="Office outpatient visit 15 minutes" codeSystemName="CPT-4" codeSystem="2.16.840.1.113883.6.12">
+  <code code="99213" displayName="Office or other outpatient visit for the evaluation and management of an established patient, which requires a medically appropriate history and/or examination and low level of medical decision making. When using time for code selection, 20-29 minutes of total time is spent on the date of the encounter." codeSystemName="CPT-4" codeSystem="2.16.840.1.113883.6.12">
     <originalText>
       <reference value="#Encounter1" />
     </originalText>
@@ -13,7 +13,7 @@
   <performer>
     <assignedEntity>
       <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
-        <code code="207Q00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Health Care Provider Taxonomy" displayName="Family Medicine" />
+        <code code="207Q00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Health Care Provider Taxonomy" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine" />
      </assignedEntity>
   </performer>
   <!--  Sample Service Delivery Location

--- a/input/examples/encounter-diagnosis-example.xml
+++ b/input/examples/encounter-diagnosis-example.xml
@@ -1,6 +1,6 @@
 <act classCode="ACT" moodCode="EVN" xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <templateId root="2.16.840.1.113883.10.20.22.4.80" extension="2015-08-01" />
-  <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="DIAGNOSIS" />
+  <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Diagnosis" />
   <text>
     <reference value="#encounterdiagnosis" />
   </text>
@@ -12,7 +12,7 @@
     <observation classCode="OBS" moodCode="EVN">
       <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2022-06-01" />      
       <id root="AB1791B0-5C71-11DB-B0DE-0800200C9A66" />
-      <code code="64572001" displayName="Condition" 
+      <code code="64572001" displayName="Disease" 
                                     codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
         <translation code="75323-6" 
               codeSystem="2.16.840.1.113883.6.1" 
@@ -41,7 +41,7 @@
         <assignedAuthor>
           <id extension="555555555" root="2.16.840.1.113883.4.6" />
           <code code="207QA0505X" 
-            displayName="Adult Medicine" 
+            displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" 
             codeSystem="2.16.840.1.113883.6.101"
             codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
           <addr use="H">

--- a/input/examples/estimated-date-of-delivery-example.xml
+++ b/input/examples/estimated-date-of-delivery-example.xml
@@ -1,7 +1,7 @@
 <observation classCode="OBS" moodCode="EVN" xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <templateId root="2.16.840.1.113883.10.20.15.3.1"/>
   <code code="11778-8" codeSystem="2.16.840.1.113883.6.1" 
-        displayName="Estimated date of delivery"/>
+        displayName="Delivery date Estimated"/>
   <text>
     <reference value="#dod" />
   </text>

--- a/input/examples/external-document-reference-example.xml
+++ b/input/examples/external-document-reference-example.xml
@@ -5,7 +5,7 @@
   <code codeSystem="2.16.840.1.113883.6.1" 
         codeSystemName="LOINC" 
         code="57133-1"
-        displayName="Referral Note" />
+        displayName="Referral note" />
   <setId extension="sTT988" root="2.16.840.1.113883.19.5.99999.19" />
   <versionNumber value="1" />
 </externalDocument>

--- a/input/examples/family-history-observation-example.xml
+++ b/input/examples/family-history-observation-example.xml
@@ -4,7 +4,7 @@
   <id root="d42ebf70-5c89-11db-b0de-0800200c9a66" />
   <code code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Condition">
     <translation code="64572001" 
-                displayName="Condition" 
+                displayName="Disease" 
                 codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"></translation>
   </code>
   <text>

--- a/input/examples/family-history-organizer-example.xml
+++ b/input/examples/family-history-organizer-example.xml
@@ -7,13 +7,13 @@
   <statusCode code="completed" />
   <subject>
     <relatedSubject classCode="PRS">
-      <code code="FTH" displayName="Father" codeSystemName="HL7 FamilyMember" codeSystem="2.16.840.1.113883.5.111">
+      <code code="FTH" displayName="father" codeSystemName="HL7 FamilyMember" codeSystem="2.16.840.1.113883.5.111">
         <translation code="9947008" displayName="Natural father" codeSystemName="SNOMED" codeSystem="2.16.840.1.113883.6.96" />
       </code>
       <subject>
         <sdtc:id root="2.16.840.1.113883.19.5.99999.2" extension="99999999" />
         <!--<id root="2.16.840.1.113883.19.5.99999.2" extension="1234" /> -->
-        <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1" />
+        <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1" displayName="Male" />
         <birthTime value="1910" />
         <!-- Example use of sdtc extensions :-->
         <!-- <sdtc:deceasedInd value="true"/><sdtc:deceasedTime value="1967"/> 
@@ -27,7 +27,7 @@
       <id root="d42ebf70-5c89-11db-b0de-0800200c9a66" />
       <code code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Condition">
         <translation code="64572001" 
-                    displayName="Condition" 
+                    displayName="Disease" 
                     codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"></translation>
       </code>
       <text>

--- a/input/examples/functional-status-observation-example.xml
+++ b/input/examples/functional-status-observation-example.xml
@@ -8,7 +8,7 @@
   </text>
   <statusCode code="completed" />
   <effectiveTime value="20130311" />
-  <value xsi:type="CD" code="129035000" displayName="independent with dressing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+  <value xsi:type="CD" code="129035000" displayName="Independent with dressing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
   <author typeCode="AUT">
     <templateId root="2.16.840.1.113883.10.20.22.4.119" />
     <time value="199803161030-0800" />

--- a/input/examples/functional-status-organizer-example.xml
+++ b/input/examples/functional-status-organizer-example.xml
@@ -40,7 +40,7 @@
       </text>
       <statusCode code="completed" />
       <effectiveTime value="20130311" />
-      <value xsi:type="CD" code="129035000" displayName="independent with dressing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+      <value xsi:type="CD" code="129035000" displayName="Independent with dressing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
       <author typeCode="AUT">
         <templateId root="2.16.840.1.113883.10.20.22.4.119" />
         <time value="199803161030-0800" />
@@ -70,7 +70,7 @@
       <!-- Self-Care Activities (ADL and IADL)-->
       <templateId root="2.16.840.1.113883.10.20.22.4.128" />
       <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0a" />
-      <code code="46482-6" displayName="Transferring" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+      <code code="46482-6" displayName="Transferring [OASIS]" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
       <text>
         <reference value="#socialhistory" />
       </text>

--- a/input/examples/functional-status-section-example.xml
+++ b/input/examples/functional-status-section-example.xml
@@ -1,7 +1,7 @@
 <section xmlns="urn:hl7-org:v3">
   <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09" />
   <!-- Functional Status Section template -->
-  <code code="47420-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Functional Status" />
+  <code code="47420-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Functional status assessment note" />
   <title>FUNCTIONAL STATUS</title>
   <text>
         ...

--- a/input/examples/general-status-section-example.xml
+++ b/input/examples/general-status-section-example.xml
@@ -3,7 +3,7 @@
   <code code="10210-3" 
           codeSystem="2.16.840.1.113883.6.1" 
           codeSystemName="LOINC" 
-          displayName="GENERAL STATUS" />
+          displayName="Physical findings of General status Narrative" />
   <title>GENERAL STATUS</title>
   <text>
     <paragraph>Alert and in good spirits, no acute distress.

--- a/input/examples/handoff-communication-example.xml
+++ b/input/examples/handoff-communication-example.xml
@@ -1,6 +1,6 @@
 <act classCode="ACT" moodCode="EVN" xmlns="urn:hl7-org:v3">
   <templateId root="2.16.840.1.113883.10.20.22.4.141" />
-  <code code="432138007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="handoff communication (procedure)" />
+  <code code="432138007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Handoff communication (procedure)" />
   <text>
     <reference value="#handoff" />
   </text>
@@ -12,7 +12,7 @@
     <assignedAuthor>
       <id root="d839038b-7171-4165-a760-467925b43857" />
       <code code="163W00000X" 
-        displayName="Registered nurse" 
+        displayName="Nursing Service Providers; Registered Nurse" 
         codeSystem="2.16.840.1.113883.6.101"
         codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
       <addr use="H">
@@ -39,7 +39,7 @@
   <participant typeCode="IRCP">
     <participantRole>
       <id root="86086fe6-fa53-4f45-9ba5-0e32bf1a50b9"/>
-      <code code="163W00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC Health Care Provider Taxonomy" displayName="Registered Nurse" />
+      <code code="163W00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC Health Care Provider Taxonomy" displayName="Nursing Service Providers; Registered Nurse" />
       <addr use="H">
         <streetAddressLine>23 Anywhere Street</streetAddressLine>
         <city>El Paso</city>

--- a/input/examples/handp-encompassingencounter-example.xml
+++ b/input/examples/handp-encompassingencounter-example.xml
@@ -2,7 +2,7 @@
   <encompassingEncounter>
     <id extension="9937012" root="2.16.840.1.113883.19" />
     <code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" 
-               code="99213" displayName="Evaluation and Management" />
+               code="99213" displayName="Office or other outpatient visit for the evaluation and management of an established patient, which requires a medically appropriate history and/or examination and low level of medical decision making. When using time for code selection, 20-29 minutes of total time is spent on the date of the encounter." />
     <effectiveTime>
       <low value="20090227130000+0500" />
       <high value="20090227130000+0500" />

--- a/input/examples/health-status-observation-example.xml
+++ b/input/examples/health-status-observation-example.xml
@@ -6,5 +6,5 @@
     <reference value="#healthstatus" />
   </text>
   <statusCode code="completed" />
-  <value xsi:type="CD" code="81323004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Alive and well" />
+  <value xsi:type="CD" code="81323004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Normal general body function" />
 </observation>

--- a/input/examples/highest-pressure-ulcer-stage-example.xml
+++ b/input/examples/highest-pressure-ulcer-stage-example.xml
@@ -9,5 +9,5 @@
   <statusCode code="completed"/>
   <value xsi:type="CD" code="421306004"
          codeSystem="2.16.840.1.113883.6.96" 
-         displayName="necrotic eschar"/>
+         displayName="Necrotic eschar"/>
 </observation>

--- a/input/examples/hospital-admission-diagnosis-example.xml
+++ b/input/examples/hospital-admission-diagnosis-example.xml
@@ -12,7 +12,7 @@
 		  <!-- ** Problem Observation ** -->
 		  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2022-06-01" />
 		  <id root="AB1791B0-5C71-11DB-B0DE-0800200C9A66" />
-		  <code code="64572001" displayName="Condition" 
+		  <code code="64572001" displayName="Disease" 
 		                                    codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
 		    <translation code="75323-6" 
 		           codeSystem="2.16.840.1.113883.6.1" 
@@ -40,7 +40,7 @@
 		    <assignedAuthor>
 		      <id extension="555555555" root="2.16.840.1.113883.4.6" />
 		      <code code="207QA0505X" 
-		        displayName="Adult Medicine" 
+		        displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" 
 		        codeSystem="2.16.840.1.113883.6.101"
 		        codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
 		      <addr use="H">

--- a/input/examples/hospital-discharge-diagnosis-example.xml
+++ b/input/examples/hospital-discharge-diagnosis-example.xml
@@ -14,7 +14,7 @@
       <!-- Problem observation template -->
       <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2022-06-01" />
       <id root="AB1791B0-5C71-11DB-B0DE-0800200C9A66" />
-      <code code="64572001" displayName="Condition" 
+      <code code="64572001" displayName="Disease" 
         codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
         <translation code="29308-4" codeSystem="2.16.840.1.113883.6.1" displayName="Diagnosis" />  
       </code>

--- a/input/examples/hospital-discharge-instructions-section-example.xml
+++ b/input/examples/hospital-discharge-instructions-section-example.xml
@@ -2,7 +2,7 @@
   <templateId root="2.16.840.1.113883.10.20.22.2.41"/>
   <code code="8653-8" codeSystem="2.16.840.1.113883.6.1" 
         codeSystemName="LOINC" 
-        displayName="HOSPITAL DISCHARGE INSTRUCTIONS"/>
+        displayName="Hospital Discharge instructions"/>
   <title>HOSPITAL DISCHARGE INSTRUCTIONS</title>
   <text>
     <list listType="ordered">

--- a/input/examples/immunization-activity-example.xml
+++ b/input/examples/immunization-activity-example.xml
@@ -4,14 +4,14 @@
   <id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92" />
   <statusCode code="completed" />
   <effectiveTime value="19981215" />
-  <routeCode code="C28161" codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="National Cancer Institute (NCI) Thesaurus" displayName="Intramuscular injection" />
+  <routeCode code="C28161" codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="National Cancer Institute (NCI) Thesaurus" displayName="Intramuscular Route of Administration" />
   <doseQuantity value="50" unit="ug" />
   <consumable>
     <manufacturedProduct classCode="MANU">
       <!-- ** Immunization medication information ** -->
       <templateId root="2.16.840.1.113883.10.20.22.4.54" extension="2014-06-09" />
       <manufacturedMaterial>
-        <code code="33" codeSystem="2.16.840.1.113883.12.292" displayName="Pneumococcal polysaccharide vaccine" codeSystemName="CVX">
+        <code code="33" codeSystem="2.16.840.1.113883.12.292" displayName="pneumococcal polysaccharide vaccine, 23 valent" codeSystemName="CVX">
           <translation code="854981" displayName="Pneumovax 23 (Pneumococcal vaccine polyvalent) Injectable Solution" codeSystemName="RxNORM" codeSystem="2.16.840.1.113883.6.88" />
         </code>
         <lotNumberText>1</lotNumberText>

--- a/input/examples/immunization-medication-information-example.xml
+++ b/input/examples/immunization-medication-information-example.xml
@@ -2,7 +2,7 @@
   <!-- ** Immunization medication information ** -->
   <templateId root="2.16.840.1.113883.10.20.22.4.54" extension="2014-06-09" />
   <manufacturedMaterial>
-    <code code="33" codeSystem="2.16.840.1.113883.12.292" displayName="Pneumococcal polysaccharide vaccine" codeSystemName="CVX">
+    <code code="33" codeSystem="2.16.840.1.113883.12.292" displayName="pneumococcal polysaccharide vaccine, 23 valent" codeSystemName="CVX">
       <translation code="854981" displayName="Pneumovax 23 (Pneumococcal vaccine polyvalent) Injectable Solution" codeSystemName="RxNORM" codeSystem="2.16.840.1.113883.6.88" />
     </code>
     <lotNumberText>1</lotNumberText>

--- a/input/examples/immunization-refusal-reason-example.xml
+++ b/input/examples/immunization-refusal-reason-example.xml
@@ -1,7 +1,7 @@
 <observation classCode="OBS" moodCode="EVN" xmlns="urn:hl7-org:v3">
   <templateId root="2.16.840.1.113883.10.20.22.4.53"/>
   <id root="2a620155-9d11-439e-92b3-5d9815ff4dd8"/>
-  <code displayName="Patient Objection" code="PATOBJ"
+  <code displayName="patient objection" code="PATOBJ"
 		codeSystemName="HL7 ActNoImmunizationReason" codeSystem="2.16.840.1.113883.5.8"/>
     <text><reference value="#immrefusal"/></text>
   <statusCode code="completed"/>

--- a/input/examples/instruction-example.xml
+++ b/input/examples/instruction-example.xml
@@ -1,6 +1,6 @@
 <act classCode="ACT" moodCode="INT" xmlns="urn:hl7-org:v3">
   <templateId root="2.16.840.1.113883.10.20.22.4.20" extension="2014-06-09" />
-  <code code="171044003" codeSystem="2.16.840.1.113883.6.96" displayName="immunization education" />
+  <code code="171044003" codeSystem="2.16.840.1.113883.6.96" displayName="Immunization education" />
   <text>
     <reference value="#immunSect" />
 		Possible flu-like symptoms for three days.

--- a/input/examples/instructions-section-example.xml
+++ b/input/examples/instructions-section-example.xml
@@ -1,6 +1,6 @@
 <section xmlns="urn:hl7-org:v3">
   <templateId root="2.16.840.1.113883.10.20.22.2.45" extension="2014-06-09" />
-  <code code="69730-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="INSTRUCTIONS" />
+  <code code="69730-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Instructions" />
   <title>INSTRUCTIONS</title>
   <text>
     Patient may have low grade fever, mild joint pain and injection area   
@@ -9,7 +9,7 @@
   <entry typeCode="DRIV">
     <act classCode="ACT" moodCode="INT" xmlns="urn:hl7-org:v3">
       <templateId root="2.16.840.1.113883.10.20.22.4.20" extension="2014-06-09" />
-      <code code="171044003" codeSystem="2.16.840.1.113883.6.96" displayName="immunization education" />
+      <code code="171044003" codeSystem="2.16.840.1.113883.6.96" displayName="Immunization education" />
       <text>
         <reference value="#immunSect" />
         Possible flu-like symptoms for three days.

--- a/input/examples/longitudinal-care-wound-observation-example.xml
+++ b/input/examples/longitudinal-care-wound-observation-example.xml
@@ -8,7 +8,7 @@
       <low value="20013103" />
     </effectiveTime>
     <value xsi:type="CD" code="425144005" codeSystem="2.16.840.1.113883.6.6" displayName="Minor open wound" />
-    <targetSiteCode code="182295001" codeSystem="2.16.840.1.113883.6.96" displayName="anterior aspect of knee" />
+    <targetSiteCode code="182295001" codeSystem="2.16.840.1.113883.6.96" displayName="Structure of anterior aspect of knee" />
     <author>
           ...
         </author>

--- a/input/examples/medical-equipment-organizer-example.xml
+++ b/input/examples/medical-equipment-organizer-example.xml
@@ -44,19 +44,19 @@
         <!-- Procedure Activity Procedure -->
       <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2022-06-01" />
       <id root="d5b614bd-01ce-410d-8726-e1fd01dcc72a" />
-      <code code="103716009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Stent Placement">
+      <code code="103716009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Placement of stent">
         <originalText>
           <reference value="#Proc1" />
         </originalText>
       </code>
       <statusCode code="completed" />
       <effectiveTime value="20130512" />
-      <targetSiteCode code="28273000" displayName="bile duct" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+      <targetSiteCode code="28273000" displayName="Bile duct structure" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
       <specimen typeCode="SPC">
         <specimenRole classCode="SPEC">
           <id root="a6d7b927-2b70-43c7-bdf3-0e7c4133062c" />
           <specimenPlayingEntity>
-            <code code="57259009" codeSystem="2.16.840.1.113883.6.96" displayName="gallbladder bile" />
+            <code code="57259009" codeSystem="2.16.840.1.113883.6.96" displayName="Gallbladder bile" />
           </specimenPlayingEntity>
         </specimenRole>
       </specimen>

--- a/input/examples/medical-equipment-section-example.xml
+++ b/input/examples/medical-equipment-section-example.xml
@@ -55,7 +55,7 @@
         <!--// Procedure Activity Procedure -->
         <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2022-06-01" />
         <id root="d5b614bd-01ce-410d-8726-e1fd01dcc72a" />
-        <code code="103716009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Stent Placement">
+        <code code="103716009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Placement of stent">
           <originalText>
             <reference value="#Proc1" />
           </originalText>
@@ -66,12 +66,12 @@
           <low value="20050412130000+0500" />
           <high value="20130512130000+0500" />
         </effectiveTime>
-        <targetSiteCode code="28273000" displayName="bile duct" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+        <targetSiteCode code="28273000" displayName="Bile duct structure" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
         <specimen typeCode="SPC">
           <specimenRole classCode="SPEC">
             <id root="a6d7b927-2b70-43c7-bdf3-0e7c4133062c" />
             <specimenPlayingEntity>
-              <code code="57259009" codeSystem="2.16.840.1.113883.6.96" displayName="gallbladder bile" />
+              <code code="57259009" codeSystem="2.16.840.1.113883.6.96" displayName="Gallbladder bile" />
             </specimenPlayingEntity>
           </specimenRole>
         </specimen>

--- a/input/examples/medication-activity-example.xml
+++ b/input/examples/medication-activity-example.xml
@@ -14,7 +14,7 @@
   <routeCode code="C38288" 
             codeSystem="2.16.840.1.113883.3.26.1.1" 
             codeSystemName="NCI Thesaurus" 
-            displayName="ORAL">
+            displayName="Oral Route of Administration">
     <translation code="26643006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED" displayName="Oral route"/>
   </routeCode>
   <doseQuantity value="1" unit="1"/>
@@ -37,7 +37,7 @@
     <assignedAuthor>
       <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
       <code code="163W00000X" 
-        displayName="Registered nurse" 
+        displayName="Nursing Service Providers; Registered Nurse" 
         codeSystem="2.16.840.1.113883.6.101" 
         codeSystemName="Health Care Provider Taxonomy (HIPAA)" />
       <addr use="H">
@@ -78,7 +78,7 @@
       </effectiveTime>
       <value xsi:type="CD" 
              code="38341003" 
-             displayName="Hypertension" 
+             displayName="Hypertensive disorder, systemic arterial" 
              codeSystem="2.16.840.1.113883.6.96"/>
     </observation>
   </entryRelationship>

--- a/input/examples/mental-status-observation-example.xml
+++ b/input/examples/mental-status-observation-example.xml
@@ -3,7 +3,7 @@
     <templateId root="2.16.840.1.113883.10.20.22.4.75" extension="2024-05-01" />
     <id root="a7bc1062-8649-42a0-833d-ekd65bd013c9" />
     <code code="75275-8" 
-                                    displayName="Cognitive function"
+                                    displayName="Cognitive function [Interpretation]"
                                     codeSystem="2.16.840.1.113883.6.1"
                                     codeSystemName="LOINC" />
     <statusCode code="completed" />
@@ -12,10 +12,10 @@
         <!-- Mental Status Observation -->
         <templateId root="2.16.840.1.113883.10.20.22.4.74" extension="2015-08-01" />
                 
-        <code code="373930000" displayName="Cognitive function" 
+        <code code="373930000" displayName="Cognitive function finding" 
                                 codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
           <translation code="75275-8" 
-                                    displayName="Cognitive function"
+                                    displayName="Cognitive function [Interpretation]"
                                     codeSystem="2.16.840.1.113883.6.1"
                                     codeSystemName="LOINC"></translation>
         </code>

--- a/input/examples/mental-status-organizer-example.xml
+++ b/input/examples/mental-status-organizer-example.xml
@@ -3,7 +3,7 @@
     <templateId root="2.16.840.1.113883.10.20.22.4.75" extension="2015-08-01" />
     <id root="a7bc1062-8649-42a0-833d-ekd65bd013c9" />
     <code code="75275-8" 
-                                    displayName="Cognitive function"
+                                    displayName="Cognitive function [Interpretation]"
                                     codeSystem="2.16.840.1.113883.6.1"
                                     codeSystemName="LOINC" />
     <statusCode code="completed" />
@@ -15,10 +15,10 @@
  
                 
                 
-        <code code="373930000" displayName="Cognitive function" 
+        <code code="373930000" displayName="Cognitive function finding" 
                                 codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
           <translation code="75275-8" 
-                                    displayName="Cognitive function"
+                                    displayName="Cognitive function [Interpretation]"
                                     codeSystem="2.16.840.1.113883.6.1"
                                     codeSystemName="LOINC"></translation>
         </code>

--- a/input/examples/nutrition-assessment-example.xml
+++ b/input/examples/nutrition-assessment-example.xml
@@ -3,7 +3,7 @@
     <templateId root="2.16.840.1.113883.10.20.22.4.138" />
     <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
     <code code="75303-8" 
-              displayName="Nutrition assessment"
+              displayName="Nutrition assessment Narrative"
               codeSystem="2.16.840.1.113883.6.1" 
               codeSystemName="LOINC" />
     <statusCode code="completed" />

--- a/input/examples/nutrition-recommendation-example.xml
+++ b/input/examples/nutrition-recommendation-example.xml
@@ -3,7 +3,7 @@
     <templateId root="2.16.840.1.113883.10.20.22.4.130" />
     <id root="9a6d1bac-17d3-4195-89a4-1121bc809a5c" />
     <code code="61310001" 
-               displayName="nutrition education" 
+               displayName="Nutrition education" 
                codeSystem="2.16.840.1.113883.6.96" 
                codeSystemName="SNOMED CT" />
     <statusCode code="active" />

--- a/input/examples/nutritional-status-observation-example.xml
+++ b/input/examples/nutritional-status-observation-example.xml
@@ -13,7 +13,7 @@
   <value xsi:type="CD" code="248324001"
           codeSystem="2.16.840.1.113883.6.96" 
           codeSystemName="SNOMED-CT" 
-          displayName="well nourished" />
+          displayName="Well nourished" />
   <entryRelationship typeCode="SUBJ">
     <observation classCode="OBS" moodCode="EVN">
       <!-- ** Nutrition Assessment** -->

--- a/input/examples/operative-note-performer-example.xml
+++ b/input/examples/operative-note-performer-example.xml
@@ -1,7 +1,7 @@
 <performer typeCode="PPRF" xmlns="urn:hl7-org:v3">
   <assignedEntity>
     <id extension="1" root="2.16.840.1.113883.19" />
-    <code code="2086S0120X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" displayName="Pediatric Surgeon" />
+    <code code="2086S0120X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" displayName="Allopathic &amp; Osteopathic Physicians; Surgery, Pediatric Surgery" />
     <addr>
       <streetAddressLine>1013 Healthcare Drive</streetAddressLine>
       <city>Ann Arbor</city>

--- a/input/examples/operative-note-serviceevent-example.xml
+++ b/input/examples/operative-note-serviceevent-example.xml
@@ -1,5 +1,5 @@
 <serviceEvent classCode="PROC" xmlns="urn:hl7-org:v3">
-  <code code="80146002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Appendectomy" />
+  <code code="80146002" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Excision of appendix" />
   <effectiveTime>
     <low value="201003292240-0500" />
     <width value="15" unit="m" />

--- a/input/examples/patient-generated-document-author-example.xml
+++ b/input/examples/patient-generated-document-author-example.xml
@@ -8,7 +8,7 @@
 				The PGD Header Template includes further conformance constraints on the code element to encode the personal or legal 
 				relationship of the author when they are person who is not acting in the role of a clinician.. 
 			-->
-    <code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
+    <code code="ONESELF" displayName="self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
     <addr use="HP">
       <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
       <streetAddressLine>2222 Home Street</streetAddressLine>

--- a/input/examples/patient-generated-document-dataenterer-example.xml
+++ b/input/examples/patient-generated-document-dataenterer-example.xml
@@ -3,7 +3,7 @@
     <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
 				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
     <id extension="adameveryman@direct.sampleHISP.com" root="2.16.123.123.12345.1234" />
-    <code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
+    <code code="ONESELF" displayName="self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
     <addr use="HP">
       <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
       <streetAddressLine>2222 Home Street</streetAddressLine>

--- a/input/examples/patient-generated-document-informant-example-informant.xml
+++ b/input/examples/patient-generated-document-informant-example-informant.xml
@@ -2,7 +2,7 @@
   <assignedEntity>
     <!-- id using HL7 example OID. -->
     <id extension="999.1" root="2.16.840.1.113883.19" />
-    <code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
+    <code code="ONESELF" displayName="self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
     <addr use="HP">
       <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
       <streetAddressLine>2222 Home Street</streetAddressLine>

--- a/input/examples/patient-generated-document-informationrecipient.xml
+++ b/input/examples/patient-generated-document-informationrecipient.xml
@@ -4,7 +4,7 @@
   <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2023-05-01" />
   <templateId root="2.16.840.1.113883.10.20.29.1" extension="2015-08-01" />
   <id root="2c1e0e12-b0ae-4456-a526-c11d5e69e77c" />
-  <code code="68831-7" displayName="Discharge summary note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <code code="68831-7" displayName="Primary care Discharge summary" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
   <title>Patient Discharge Summary</title>
   <effectiveTime value="201308151030-0800" />
   <confidentialityCode code="N" displayName="normal" codeSystem="2.16.840.1.113883.5.25" codeSystemName="Confidentiality" />
@@ -61,7 +61,7 @@
 		<time value="201308151030-0800"/>
 		<assignedAuthor>
 			<id extension="5555555555" root="2.16.840.1.113883.4.6"/>
-			<code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+			<code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
 			<addr use="WP">
 				<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 				<city>Portland</city>
@@ -156,7 +156,7 @@
 		<signatureCode code="S"/>
 		<assignedEntity>
 			<id extension="555555555" root="2.16.840.1.113883.4.6"/>
-			<code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+			<code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
 			<addr>
 				<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 				<city>Portland</city>

--- a/input/examples/patient-generated-document-participant-example.xml
+++ b/input/examples/patient-generated-document-participant-example.xml
@@ -4,7 +4,7 @@
     <high value="20121126" />
   </time>
   <associatedEntity classCode="NOK">
-    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" displayName="mother" />
     <addr>
       <streetAddressLine>17 Daws Rd.</streetAddressLine>
       <city>Blue Bell</city>

--- a/input/examples/patient-referral-act-example.xml
+++ b/input/examples/patient-referral-act-example.xml
@@ -42,7 +42,7 @@
             codeSystem="2.16.840.1.113883.5.7" 
             codeSystemName="ActPriority" 
             displayName="ASAP"/>
-        <value xsi:type="CD" code="268528005" displayName="full care by specialist" codeSystem="2.16.840.1.113883.6.96" />
+        <value xsi:type="CD" code="268528005" displayName="Full care by specialist" codeSystem="2.16.840.1.113883.6.96" />
       </observation>
     </entryRelationship>
 </act>

--- a/input/examples/plan-of-treatment-section-example.xml
+++ b/input/examples/plan-of-treatment-section-example.xml
@@ -1,7 +1,7 @@
 <section xmlns="urn:hl7-org:v3">
     <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09" />
     <!--  **** Plan of Treatment Section template  **** -->
-    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Treatment plan" />
+    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Plan of care note" />
     <title>TREATMENT PLAN</title>
     <text>
            ...

--- a/input/examples/planned-act-example.xml
+++ b/input/examples/planned-act-example.xml
@@ -1,7 +1,7 @@
 <act classCode="ACT" moodCode="INT" xmlns="urn:hl7-org:v3">
   <templateId root="2.16.840.1.113883.10.20.22.4.39" extension="2014-06-09" />
   <id root="7658963e-54da-496f-bf18-dea1dddaa3b0" />
-  <code code="423171007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Elevate head of bed" />
+  <code code="423171007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Elevation of head of bed" />
   <statusCode code="active" />
   <effectiveTime value="20130902" />
   <author typeCode="AUT">

--- a/input/examples/planned-encounter-example.xml
+++ b/input/examples/planned-encounter-example.xml
@@ -2,7 +2,7 @@
     <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09" />
     <!-- Planned Encounter template -->
     <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4d" />
-    <code code="185349003" displayName="encounter for check-up (procedure)" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96"></code>
+    <code code="185349003" displayName="Encounter for check up (procedure)" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96"></code>
     <statusCode code="active" />
     <effectiveTime value="20130615" />
     <performer>

--- a/input/examples/planned-supply-example.xml
+++ b/input/examples/planned-supply-example.xml
@@ -16,11 +16,11 @@
       <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
       <id root="2a620155-9d11-439e-92b3-5d9815ff4ee8" />
       <manufacturedMaterial>
-        <code code="573621" codeSystem="2.16.840.1.113883.6.88" displayName="Proventil 0.09 MG/ACTUAT inhalant solution">
+        <code code="573621" codeSystem="2.16.840.1.113883.6.88" displayName="albuterol 0.09 MG/ACTUAT [Proventil]">
           <originalText>
             <reference value="#MedSec_1" />
           </originalText>
-          <translation code="573621" displayName="Proventil 0.09 MG/ACTUAT inhalant solution" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" />
+          <translation code="573621" displayName="albuterol 0.09 MG/ACTUAT [Proventil]" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" />
         </code>
       </manufacturedMaterial>
       <manufacturerOrganization>

--- a/input/examples/policy-activity-example.xml
+++ b/input/examples/policy-activity-example.xml
@@ -4,7 +4,7 @@
   <code code="12" displayName="Medicare Secondary Working Aged Beneficiary or Spouse with Employer Group Health Plan" 
              codeSystemName="Insurance Type Code (x12N-1336)"
              codeSystem="2.16.840.1.113883.6.255.1336">
-    <translation code="2" displayName="Medicare" 
+    <translation code="2" displayName="MEDICAID" 
                                     codeSystem="2.16.840.1.113883.3.221.5" codeSystemName="Source of Payment Typology (PHDSC)"></translation>
   </code>
   <statusCode code="completed" />
@@ -17,7 +17,7 @@
     </time>
     <assignedEntity>
       <id root="2.16.840.1.113883.19" />
-      <code code="PAYOR" codeSystem="2.16.840.1.113883.5.110" codeSystemName="HL7 RoleCode" />
+      <code code="PAYOR" codeSystem="2.16.840.1.113883.5.110" codeSystemName="HL7 RoleCode" displayName="invoice payor" />
       <addr use="WP">
         <streetAddressLine>123 Insurance Road</streetAddressLine>
         <city>Blue Bell</city>
@@ -49,7 +49,7 @@
     </time>
     <assignedEntity>
       <id root="329fcdf0-7ab3-11db-9fe1-0800200c9a66" />
-      <code code="GUAR" codeSystem="2.16.840.1.113883.5.110" codeSystemName="HL7 RoleCode" />
+      <code code="GUAR" codeSystem="2.16.840.1.113883.5.110" codeSystemName="HL7 RoleCode" displayName="guarantor" />
       <addr use="HP">
         <streetAddressLine>17 Daws Rd.</streetAddressLine>
         <city>Blue Bell</city>
@@ -78,7 +78,7 @@
     <participantRole classCode="PAT">
       <!-- Health plan ID for patient. -->
       <id root="1.1.1.1.1.1.1.1.14" extension="1138345" />
-      <code code="FAMDEP" codeSystem="2.16.840.1.113883.5.111" />
+      <code code="FAMDEP" codeSystem="2.16.840.1.113883.5.111" displayName="family dependent" />
       <addr use="HP">
         <streetAddressLine>17 Daws Rd.</streetAddressLine>
         <city>Blue Bell</city>

--- a/input/examples/pregnancy-observation-example.xml
+++ b/input/examples/pregnancy-observation-example.xml
@@ -7,7 +7,7 @@
     <low value="20110410"/>
   </effectiveTime>
   <value xsi:type="CD" code="77386006" 
-         displayName="pregnant" 
+         displayName="Pregnancy" 
          codeSystem="2.16.840.1.113883.6.96"/>
   <entryRelationship typeCode="REFR">
     <templateId root="2.16.840.1.113883.10.20.15.3.1"/>

--- a/input/examples/problem-concern-act-example.xml
+++ b/input/examples/problem-concern-act-example.xml
@@ -18,7 +18,7 @@
     <time value="201307061145-0800" />
     <assignedAuthor>
       <id extension="555555555" root="2.16.840.1.113883.4.6" />
-      <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101"
+      <code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101"
         codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
       <addr nullFlavor="UNK" />
       <telecom nullFlavor="UNK" />
@@ -53,7 +53,7 @@
         <assignedAuthor>
           <id extension="555555555" root="2.16.840.1.113883.4.6" />
           <code code="207QA0505X" 
-                displayName="Adult Medicine" 
+                displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" 
                 codeSystem="2.16.840.1.113883.6.101"
                 codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
           <!-- addr / telecom / name are the same as above -->

--- a/input/examples/problem-observation-example.xml
+++ b/input/examples/problem-observation-example.xml
@@ -2,7 +2,7 @@
   <!-- ** Problem Observation ** -->
   <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2024-05-01" />
   <id root="AB1791B0-5C71-11DB-B0DE-0800200C9A66" />
-  <code code="64572001" displayName="Condition" 
+  <code code="64572001" displayName="Disease" 
                                     codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
     <translation code="75323-6" 
            codeSystem="2.16.840.1.113883.6.1" 
@@ -30,7 +30,7 @@
     <assignedAuthor>
       <id extension="555555555" root="2.16.840.1.113883.4.6" />
       <code code="207QA0505X" 
-        displayName="Adult Medicine" 
+        displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" 
         codeSystem="2.16.840.1.113883.6.101"
         codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
       <addr use="H">

--- a/input/examples/problem-observation-postcoordsnomed-example.xml
+++ b/input/examples/problem-observation-postcoordsnomed-example.xml
@@ -2,7 +2,7 @@
   <!-- ** Problem Observation ** -->
   <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2024-05-01" />
   <id root="AB1791B0-5C71-11DB-B0DE-0800200C9A66" />
-  <code code="64572001" displayName="Condition" 
+  <code code="64572001" displayName="Disease" 
                                     codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
     <translation code="75323-6" 
            codeSystem="2.16.840.1.113883.6.1" 
@@ -34,7 +34,7 @@
     <assignedAuthor>
       <id extension="555555555" root="2.16.840.1.113883.4.6" />
       <code code="207QA0505X" 
-        displayName="Adult Medicine" 
+        displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" 
         codeSystem="2.16.840.1.113883.6.101"
         codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
     </assignedAuthor>

--- a/input/examples/procedure-activity-procedure-example.xml
+++ b/input/examples/procedure-activity-procedure-example.xml
@@ -2,19 +2,19 @@
   <!-- Procedure Activity Procedure -->
   <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2024-05-01" />
   <id root="d5b614bd-01ce-410d-8726-e1fd01dcc72a" />
-  <code code="103716009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Stent Placement">
+  <code code="103716009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Placement of stent">
     <originalText>
       <reference value="#Proc1" />
     </originalText>
   </code>
   <statusCode code="completed" />
   <effectiveTime value="20130512" />
-  <targetSiteCode code="28273000" displayName="bile duct" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+  <targetSiteCode code="28273000" displayName="Bile duct structure" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
   <specimen typeCode="SPC">
     <specimenRole classCode="SPEC">
       <id root="a6d7b927-2b70-43c7-bdf3-0e7c4133062c" />
       <specimenPlayingEntity>
-        <code code="57259009" codeSystem="2.16.840.1.113883.6.96" displayName="gallbladder bile" />
+        <code code="57259009" codeSystem="2.16.840.1.113883.6.96" displayName="Gallbladder bile" />
       </specimenPlayingEntity>
     </specimenRole>
   </specimen>

--- a/input/examples/prognosis-coded-example.xml
+++ b/input/examples/prognosis-coded-example.xml
@@ -10,5 +10,5 @@
     <effectiveTime>
       <low value="20130301" />
     </effectiveTime>
-    <value xsi:type="CD" code="67334001" codeSystem="2.16.840.1.113883.6.96" displayName="guarded prognosis" codeSystemName="SNOMED CT" />
+    <value xsi:type="CD" code="67334001" codeSystem="2.16.840.1.113883.6.96" displayName="Guarded prognosis" codeSystemName="SNOMED CT" />
 </observation>

--- a/input/examples/progress-note-encompassingencounter-example.xml
+++ b/input/examples/progress-note-encompassingencounter-example.xml
@@ -2,7 +2,7 @@
   <encompassingEncounter>
     <id extension="9937012" root="2.16.840.1.113883.19" />
     <code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" code="99213" 
-               displayName="Evaluation and Management" />
+               displayName="Office or other outpatient visit for the evaluation and management of an established patient, which requires a medically appropriate history and/or examination and low level of medical decision making. When using time for code selection, 20-29 minutes of total time is spent on the date of the encounter." />
     <effectiveTime>
       <low value="20090227130000+0500" />
       <high value="20090227130000+0500" />

--- a/input/examples/referral-note-caregiver-example.xml
+++ b/input/examples/referral-note-caregiver-example.xml
@@ -1,8 +1,8 @@
 <participant typeCode="IND" xmlns="urn:hl7-org:v3">
-  <functionCode code="407543004" displayName="Primary Carer" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+  <functionCode code="407543004" displayName="Primary caregiver" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
   <!-- Caregiver -->
   <associatedEntity classCode="CAREGIVER">
-    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" displayName="mother" />
     <addr>
       <streetAddressLine>17 Daws Rd.</streetAddressLine>
       <city>Ann Arbor</city>

--- a/input/examples/related-person-relationship-and-name-example.xml
+++ b/input/examples/related-person-relationship-and-name-example.xml
@@ -7,7 +7,7 @@
   <associatedEntity classCode="PRS">
     <!-- classCode "PRS" represents personal relationship -->
     <!-- Personal And Legal Relationship Role Type Value Set -->
-    <code code="MTH" codeSystem="2.16.840.1.113883.5.111"/>
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" displayName="mother" />
     <!-- OPTIONAL US Realm Address -->
     <addr use="HP">
       <streetAddressLine>2222 Home Street</streetAddressLine>

--- a/input/examples/result-observation-example.xml
+++ b/input/examples/result-observation-example.xml
@@ -6,7 +6,7 @@ codeSystemName="LOINC" />
   <statusCode code="completed" />
   <effectiveTime value="200803190830-0800" />
   <value xsi:type="PQ" value="35.3" unit="%" />
-  <interpretationCode code="L" codeSystem="2.16.840.1.113883.5.83" />
+  <interpretationCode code="L" codeSystem="2.16.840.1.113883.5.83" displayName="Low" />
   <author>
     <time value="200803190830-0800" />
     <assignedAuthor>
@@ -38,7 +38,7 @@ codeSystemName="LOINC" />
         <low value="34.9" unit="%" />
         <high value="44.5" unit="%" />
       </value>
-      <interpretationCode code="L" codeSystem="2.16.840.1.113883.5.83"/>
+      <interpretationCode code="L" codeSystem="2.16.840.1.113883.5.83" displayName="Low" />
     </observationRange>
   </referenceRange>
 </observation>

--- a/input/examples/risk-concern-act-example.xml
+++ b/input/examples/risk-concern-act-example.xml
@@ -19,7 +19,7 @@
       <effectiveTime>
         <low value="20130613" />
       </effectiveTime>
-      <value xsi:type="CD" code="409623005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Malignant neoplastic disease" />
+      <value xsi:type="CD" code="409623005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Respiratory insufficiency" />
     </observation>
   </entryRelationship>
   ...

--- a/input/examples/section-time-range-example.xml
+++ b/input/examples/section-time-range-example.xml
@@ -1,8 +1,8 @@
 <!--  Section Time Range Observation -->
 <observation xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" classCode="OBS" moodCode="EVN">
-  <templateId root="2.16.840.1.113883.10.20.22.4.68.99999"/>
-  <code code="X-SECTIONTIMERANGE" codeSystem="2.16.840.1.113883.6.1" 
-                displayName="Section Date and Time Range"/>
+  <templateId root="2.16.840.1.113883.10.20.22.4.201" extension="2016-06-01" />
+  <code code="82607-3" codeSystem="2.16.840.1.113883.6.1" 
+                displayName="Clinical data [Date and Time Range]"/>
   <text>
     <reference value="#TS_Narrative1"/>
   </text>

--- a/input/examples/self-care-activities-adl-and-iadl-example.xml
+++ b/input/examples/self-care-activities-adl-and-iadl-example.xml
@@ -2,7 +2,7 @@
   <!-- Self Care Activities (NEW)-->
   <templateId root="2.16.840.1.113883.10.20.22.4.128" />
   <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0a" />
-  <code code="46482-6" displayName="Transferring" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <code code="46482-6" displayName="Transferring [OASIS]" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
   <text>
     <reference value="#socialhistory" />
   </text>

--- a/input/examples/sensory-and-speech-status-example.xml
+++ b/input/examples/sensory-and-speech-status-example.xml
@@ -2,7 +2,7 @@
     <!-- Sensory and Speech Status(NEW)-->
     <templateId root="2.16.840.1.113883.10.20.22.4.127" />
     <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0a" />
-    <code code="47078008" displayName="Hearing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    <code code="47078008" displayName="Hearing, function" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
     <text>
       <reference value="#socialhistory" />
     </text>

--- a/input/examples/smoking-status-meaningful-use-example.xml
+++ b/input/examples/smoking-status-meaningful-use-example.xml
@@ -9,7 +9,7 @@
   <!-- The effectiveTime reflects when the current smoking status was observed. -->
   <effectiveTime value="20120910" />
   <!-- The value represents the patient's smoking status currently observed. -->
-  <value code="8517006" displayName="Former smoker" codeSystem="2.16.840.1.113883.6.96" />
+  <value xsi:type="CD" code="8517006" displayName="Former smoker" codeSystem="2.16.840.1.113883.6.96" />
   <author typeCode="AUT">
     <templateId root="2.16.840.1.113883.10.20.22.4.119" />
     <time value="199803161030-0800" />

--- a/input/examples/smoking-status-meaningful-use-example.xml
+++ b/input/examples/smoking-status-meaningful-use-example.xml
@@ -9,7 +9,7 @@
   <!-- The effectiveTime reflects when the current smoking status was observed. -->
   <effectiveTime value="20120910" />
   <!-- The value represents the patient's smoking status currently observed. -->
-  <value xsi:type="CD" code="8517006" displayName="Former smoker" codeSystem="2.16.840.1.113883.6.96" />
+  <value xsi:type="CD" code="8517006" displayName="Ex-smoker" codeSystem="2.16.840.1.113883.6.96" />
   <author typeCode="AUT">
     <templateId root="2.16.840.1.113883.10.20.22.4.119" />
     <time value="199803161030-0800" />

--- a/input/examples/social-history-section-example.xml
+++ b/input/examples/social-history-section-example.xml
@@ -26,7 +26,7 @@
         <!-- The effectiveTime reflects when the current smoking status was observed. -->
         <effectiveTime value="20120910" />
         <!-- The value represents the patient's smoking status currently observed. -->
-        <value xsi:type="CD" code="8517006" displayName="Former smoker" codeSystem="2.16.840.1.113883.6.96" />
+        <value xsi:type="CD" code="8517006" displayName="Ex-smoker" codeSystem="2.16.840.1.113883.6.96" />
         <author typeCode="AUT">
           <templateId root="2.16.840.1.113883.10.20.22.4.119" />
           <time value="199803161030-0800" />

--- a/input/examples/tobacco-use-example.xml
+++ b/input/examples/tobacco-use-example.xml
@@ -13,7 +13,7 @@
     <!-- The high value reflects the end date of the observation/value (moderate smoker) -->
     <high value="20110215" />
   </effectiveTime>
-  <value xsi:type="CD" code="160604004" displayName="Moderate cigarette smoker, 10-19/day" codeSystem="2.16.840.1.113883.6.96" />  
+  <value xsi:type="CD" code="160604004" displayName="Moderate cigarette smoker" codeSystem="2.16.840.1.113883.6.96" />  
   <author typeCode="AUT">
     <templateId root="2.16.840.1.113883.10.20.22.4.119" />
     <time value="201209101145-0800" />

--- a/input/examples/transfer-summary-participant-support-example.xml
+++ b/input/examples/transfer-summary-participant-support-example.xml
@@ -1,11 +1,11 @@
 <participant typeCode="IND" xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <functionCode code="407543004" displayName="Primary Carer" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    <functionCode code="407543004" displayName="Primary caregiver" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
     <time>
       <low value="19590101" />
       <high value="20111025" />
     </time>
     <associatedEntity classCode="CAREGIVER">
-      <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+      <code code="MTH" codeSystem="2.16.840.1.113883.5.111" displayName="mother" />
       <addr>
         <streetAddressLine>17 Daws Rd.</streetAddressLine>
         <city>Ann Arbor</city>

--- a/input/examples/us-realm-date-and-time-ivl-example.xml
+++ b/input/examples/us-realm-date-and-time-ivl-example.xml
@@ -1,5 +1,5 @@
 <!-- effectiveTime element with IVL<TS> data type precise to the second for an observation -->
 <effectiveTime xmlns="urn:hl7-org:v3">
-  <low value='20110706122735-0800'/>
-  <high value='20110706122815-0800'/>
+  <low value="20110706122735-0800"/>
+  <high value="20110706122815-0800"/>
 </effectiveTime>

--- a/input/examples/us-realm-header-example.xml
+++ b/input/examples/us-realm-header-example.xml
@@ -5,7 +5,7 @@
   <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2023-05-01" />
   <!-- Globally unique identifier for the document  -->
   <id extension="TT988" root="2.16.840.1.113883.19.5.99999.1" />
-  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <code code="34133-9" displayName="Summary of episode note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
   <!-- Title of the document -->
   <title>Patient Chart Summary</title>
   <effectiveTime value="201209151030-0800" />
@@ -45,7 +45,7 @@
 					categories defined by OMB Standards -->
 				<raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<!-- The raceCode extension is only used if raceCode is valued -->
-				<sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
+				<sdtc:raceCode code="2076-8" displayName="Native Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC"/>
 				<guardian>
 					<code code="POWATT" displayName="Power of Attorney" codeSystem="2.16.840.1.113883.1.11.19830" codeSystemName="ResponsibleParty"/>
@@ -92,7 +92,7 @@
 		<time value="201308151030-0800"/>
 		<assignedAuthor>
 			<id extension="5555555555" root="2.16.840.1.113883.4.6"/>
-			<code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+			<code code="207QA0505X" displayName="Allopathic &amp; Osteopathic Physicians; Family Medicine, Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
 			<addr>
 				<streetAddressLine>1004 Healthcare Drive </streetAddressLine>
 				<city>Portland</city>

--- a/input/examples/us-realm-header-example.xml
+++ b/input/examples/us-realm-header-example.xml
@@ -129,7 +129,7 @@
 		</assignedCustodian>
 	</custodian>
   <informationRecipient>
-    <intendedRecipient classCode="ohlookyouarenotbound">
+    <intendedRecipient>
       <addr>
 				<streetAddressLine>1004 Healthcare Drive</streetAddressLine>
 				<city>Portland</city>

--- a/input/examples/vital-sign-observation-example.xml
+++ b/input/examples/vital-sign-observation-example.xml
@@ -2,7 +2,7 @@
   <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
   <!-- Vital Sign Observation template -->
   <id root="c6f88321-67ad-11db-bd13-0800200c9a66" />
-  <code code="8302-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Height" />
+  <code code="8302-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Body height" />
   <text>
     <reference value="#reaction2" />
   </text>

--- a/input/examples/vital-signs-organizer-example.xml
+++ b/input/examples/vital-signs-organizer-example.xml
@@ -23,7 +23,7 @@
       <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
       <!-- Vital Sign Observation template -->
       <id root="c6f88321-67ad-11db-bd13-0800200c9a66" />
-      <code code="8302-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Height" />
+      <code code="8302-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Body height" />
       <text>
         <reference value="#reaction2" />
       </text>


### PR DESCRIPTION
This PR encompasses several fixes to C-CDA examples for 3.0. Additionally (and this part might be controversial), the final commit pulls in displayNames from VSAC for every code where a displayName could be found. If we don't like that last part, we can just focus on the other four commits.